### PR TITLE
Add disclaimers in footer , about page, and application FAQ page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -23,19 +23,17 @@ content was written by [Tom Fifield](https://twitter.com/tomfifield). Credit is 
  community there, many people would never have discovered the Gold Card or made it through their
 applications.
 
+ We are not affiliated with any government departments and information may be inaccurate and/or outdated. As 
+ changes and errors may occur, please seek professional advice from the relevant officials where necessary. 
+ Contains content licensed under the Government Website Open Information Announcement. 
+ taiwangoldcard.com, its contributors, and maintainers cannot be held liable for the accuracy of the information 
+ or for ensuring that the information is up to date at all times.
 
 Content and the underlying site is contributed by a volunteer community that you are
  [welcome to join](https://github.com/taiwangoldcard/website). Contributions to code are licensed under
  the Apache 2.0 license, and contributions of content for the FAQ are licensed under the Creative Commons
  CC-BY-SA-NC license. The license text can be found in
  [our repository](https://github.com/taiwangoldcard/website/blob/master/LICENSE.md).
-
- We are not affiliated with any government departments and information may be inaccurate and/or outdated. As 
- changes and errors may occur,
- please seek professional advice from the relevant officials where necessary. Contains content licensed under
- the Government Website Open Information Announcement. taiwangoldcard.com, its contributors, and maintainers
-  cannot be held liable for the accuracy of the information or for ensuring that the information is up to date
-  at all times.
 
 {{< /column >}}
 

--- a/content/about.md
+++ b/content/about.md
@@ -30,6 +30,12 @@ Content and the underlying site is contributed by a volunteer community that you
  CC-BY-SA-NC license. The license text can be found in
  [our repository](https://github.com/taiwangoldcard/website/blob/master/LICENSE.md).
 
+ We are not affiliated with any government departments and information may be inaccurate and/or outdated. As 
+ changes and errors may occur,
+ please seek professional advice from the relevant officials where necessary. Contains content licensed under
+ the Government Website Open Information Announcement. taiwangoldcard.com, its contributors, and maintainers
+  cannot be held liable for the accuracy of the information or for ensuring that the information is up to date
+  at all times.
 
 {{< /column >}}
 

--- a/content/application-faq/_index.md
+++ b/content/application-faq/_index.md
@@ -8,12 +8,13 @@ skilled professionals. Please choose a menu entry to find out more about how you
  or [the steps to apply](/application-faq/application/).
 
 
-Disclaimers:
-This compilation of information is provided on a **best-effort** basis by Gold Card holders.
-It could be outdated or incorrect.
+### Disclaimers:
 
-Seek qualified advice directly from government authorities, licensed migration agents, lawyers and accountants. 
-We are neither lawyers, migration agents nor have any relationship with the government.
+This compilation of information is provided on a **best-effort** basis by Gold Card holders.
+We are not affiliated with any government departments and information may be inaccurate and/or outdated
+
+We are neither lawyers, migration agents nor have any relationship with the government. As changes and errors may occur, please seek professional advice from the relevant officials where necessary. taiwangoldcard.com, its contributors, and maintainers cannot be held liable for the accuracy of the information or for ensuring that the information is up to date at all times.
+
 
 If you are in Taiwan, you can head over the [National Immigration Agency](https://www.immigration.gov.tw/5475/5478/141386/127061/127076/)
  if you'd like to talk face to face to an agent. There is also [a list of helpful contact information](/application-faq/application/#who-can-i-talk-to-about-this)

--- a/content/application-faq/_index.md
+++ b/content/application-faq/_index.md
@@ -11,7 +11,6 @@ skilled professionals. Please choose a menu entry to find out more about how you
 ### Disclaimers:
 
 This compilation of information is provided on a **best-effort** basis by Gold Card holders.
-We are not affiliated with any government departments and information may be inaccurate and/or outdated
 
 We are neither lawyers, migration agents nor have any relationship with the government. As changes and errors may occur, please seek professional advice from the relevant officials where necessary. taiwangoldcard.com, its contributors, and maintainers cannot be held liable for the accuracy of the information or for ensuring that the information is up to date at all times.
 

--- a/themes/compose/layouts/partials/footer.html
+++ b/themes/compose/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.enableCopyright | default true }}
 <footer class="mt-2 pt-2 pb-2">
   <div class="wrap">
-	  <p>&copy; {{ now.Year }} {{ .Site.Params.author }} - <a href="/about">About</a></p>
+    <p>taiwangoldcard.com is maintained by the Gold Card Community. We are not affiliated with any government departments - <a href="/about">About</a> </p>
   </div>
 </footer>
 {{ end }}

--- a/themes/compose/layouts/partials/footer.html
+++ b/themes/compose/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.enableCopyright | default true }}
 <footer class="mt-2 pt-2 pb-2">
   <div class="wrap">
-    <p>taiwangoldcard.com is maintained by the Gold Card Community. We are not affiliated with any government departments - <a href="/about">About us</a> </p>
+    <p>taiwangoldcard.com is maintained by Gold Card Holders. We are not affiliated with any government departments - <a href="/about">About us</a> </p>
   </div>
 </footer>
 {{ end }}

--- a/themes/compose/layouts/partials/footer.html
+++ b/themes/compose/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.enableCopyright | default true }}
 <footer class="mt-2 pt-2 pb-2">
   <div class="wrap">
-    <p>taiwangoldcard.com is maintained by the Gold Card Community. We are not affiliated with any government departments - <a href="/about">About</a> </p>
+    <p>taiwangoldcard.com is maintained by the Gold Card Community. We are not affiliated with any government departments - <a href="/about">About us</a> </p>
   </div>
 </footer>
 {{ end }}


### PR DESCRIPTION

Here the disclaimers I've added based on everyone's suggestion in https://github.com/taiwangoldcard/website/issues/32
 : 


![Screen Recording 2020-06-26 at 10 46 PM](https://user-images.githubusercontent.com/3368263/85870496-a9b55c00-b7ff-11ea-84ed-e80b6d6d671f.gif)


### Footer, appear in every pages, I've kept it short for now, a too long text isn't pretty 
> taiwangoldcard.com is maintained by Gold Card Holders. We are not affiliated with any government departments 

### FAQ Application page "index" page : 
> This compilation of information is provided on a **best-effort** basis by Gold Card holders. We are neither lawyers, migration agents nor have any relationship with the government. As changes and errors may occur, please seek professional advice from the relevant officials where necessary. taiwangoldcard.com, its contributors, and maintainers cannot be held liable for the accuracy of the information or for ensuring that the information is up to date at all times.

### About page: 
> We are not affiliated with any government departments and information may be inaccurate and/or outdated. As 
 changes and errors may occur, please seek professional advice from the relevant officials where necessary. 
 Contains content licensed under the Government Website Open Information Announcement. 
 taiwangoldcard.com, its contributors, and maintainers cannot be held liable for the accuracy of the information 
 or for ensuring that the information is up to date at all times.

@fifieldt @iansinnott @pqvst @jliao-tw I think it is good enough for now. Will deploy this in a few minutes since it seems urgent
