### PR TITLE
Application content redesign

### DIFF
--- a/content/application-faq/after-passing-skill-assessment.md
+++ b/content/application-faq/after-passing-skill-assessment.md
@@ -1,0 +1,66 @@
+---
+title: "After passing skill assessment"
+weight: 5
+---
+<!--- (c) Tom Fifield, licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. -->
+Congratulations! The long and hard part is now over: you've been deemed sufficiently
+skilled to hold a Gold Card.
+
+All that's left is Identity Verification and you can collect your card!
+
+## Identity Verification
+🕑 1-2 weeks
+
+Congratulations on passing the skill assessment. It's now time to deliver your passport
+ for identity verification.
+1. If you are overseas, you should visit the nearest Taiwanese diplomatic post
+1. If you are in Taiwan, you must visit the Bureau of Consular Affairs
+
+
+### If I apply in Taiwan, where do I go to prove my identity?
+You must go to your [local Bureau of Consular Affairs (BOCA)](https://www.boca.gov.tw/lp-191-2.html).
+ If you’re getting your passport vetted at Taipei’s BOCA/MOFA office, here’s a quick how-to.
+(Don’t worry, the ‘pinball’ method - shuffling between volunteers - works well too).
+
+1. BOCA is open between 08:30 to 17:00, [a few blocks from Shandao Temple Station, Exit 2](https://goo.gl/maps/mFt8PBMCGnD2) 
+1. Enter the big pink building and go directly up the escalators to level 3
+1. On 3F, ignore the ticket machine immediately in front of you and turn right and right again to be at the “Authentication” area
+1. In the middle of the area, around counter 30, grab a ticket (if there is a problem, ask for help at the end counter - counter 28)
+1. Go to the designated counter when your number is up, surrender your passport and online
+ application document, provide any details on upcoming travel, and receive your receipt.
+
+
+### Is there anything special I should do if I applied from overseas?
+If you live far from your local Taiwanese diplomatic post, it is recommended to call before going
+ to give them a heads up. It’s highly likely that you’re the first person ever to go through this
+ process in a particular office and giving them a day or two head start to let them call back to
+ Taiwan and work out what to do when you arrive could be useful.
+
+> If your application is stuck on "Under inspection" after you already collected your passport,
+    contact the NIA - your card may already be printed.
+
+## Card Collection
+🕑 1-2 weeks
+
+After your identity is verified, a final review is conducted by the Ministry of Interior and 
+your Gold Card will be issued. You will get an email at this point telling you your application has
+been approved - congratulations.
+
+It's time to collect your card (you selected where during your application)
+    1. in Taiwan at the National Immigration Agency
+    1. at your nearest Taiwanesediplomatic post
+
+If you applied from overseas but are collecting your card in Taiwan, you will need to download your
+ Resident Authorization Letter from the [portal](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card)
+ and print it. Your airline will need to see this as proof of your ability to enter Taiwan, and you'll
+ show it to the border agent in Taiwan. After arriving, you may visit the 
+ [National Immigration Agency](https://www.immigration.gov.tw/5475/5478/141386/127061/127076/)
+ to collect your card.
+
+> You don't need to go to Taiwan straight away: some people take months to prepare for their arrival.
+> However, see the answer for
+> [When does the gold card's validity begin?](/goldcard-holders-faq/validity/) to determine whether that affects you.
+
+When you are ready, head over to the [main page](/) and Join the Gold Card Community, or find out about
+ [Life in Taiwan](/goldcard-holders-faq).

--- a/content/application-faq/after-submitting-application.md
+++ b/content/application-faq/after-submitting-application.md
@@ -5,6 +5,13 @@ weight: 4
 <!--- (c) Tom Fifield, licensed under a
 Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. -->
 
+> ⓘ _Note: you will receive an email at this point telling you to pay. If you didn't get it, check your email address was correct._
+
+You must then go through the payment steps in order for your application to be considered.
+
+> ⓘ _Note: you will receive an email at this point telling you to get your receipt. Follow the steps to download it, and print it out - you will need it to collect your card._
+
+
 ## What happens after you submit your application?
 1. Your qualifications will be assessed.
     1. First, the Ministry of Labor will attempt to sign off on the work permit. If it can do this itself (eg you apply based on the salary criteria and provide the right documents), your application will be swift (one case took just two days).
@@ -90,6 +97,15 @@ You must go to your local Bureau of Consular Affairs (BOCA). If you’re getting
 1. In the middle of the area, around counter 30, grab a ticket (if there is a problem, ask for help at the end counter - counter 28)
 1. Go to the designated counter when your number is up, surrender your passport and online
  application document, provide any details on upcoming travel, and receive your receipt.
+
+
+## Is there anything special I should do if I applied from overseas?
+
+If you live far from your local Taiwanese diplomatic post, it is recommended to call before going
+ to give them a heads up. It’s highly likely that you’re the first person ever to go through this
+ process in a particular office and giving them a day or two head start to let them call back to
+ Taiwan and work out what to do when you arrive could be useful.
+
 
 
 ## What is a "Resident Authorization Letter"?

--- a/content/application-faq/after-submitting-application.md
+++ b/content/application-faq/after-submitting-application.md
@@ -4,67 +4,61 @@ weight: 4
 ---
 <!--- (c) Tom Fifield, licensed under a
 Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. -->
+Congratulations on getting the application in.
 
-> ⓘ _Note: you will receive an email at this point telling you to pay. If you didn't get it, check your email address was correct._
+At this point you will receive an email at this point telling you to pay.
+If you didn't get it, check your email address was correct.
 
-You must then go through the payment steps in order for your application to be considered.
+_You must now go through the payment steps in order for your application to be considered._
 
-> ⓘ _Note: you will receive an email at this point telling you to get your receipt. Follow the steps to download it, and print it out - you will need it to collect your card._
+Log in to the portal at:
+[https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card)
 
+click "Online Payment" and select "Permit Payment", then follow the steps.
 
-## What happens after you submit your application?
-1. Your qualifications will be assessed.
-    1. First, the Ministry of Labor will attempt to sign off on the work permit. If it can do this itself (eg you apply based on the salary criteria and provide the right documents), your application will be swift (one case took just two days).
-    1. If the Ministry of Labor can't vet your skills, it will call in the appropriate Ministry (eg "Science and Technology) to assist. That Ministry will then create a custom panel of judges who are skilled in your area of application. This takes some time, and if you are skilled in a niche area expect the application to take longer than 30 days at this stage.
-1. Your identity will be verified
-    1. If you are overseas, you will visit the nearest Taiwanese diplomatic post
-    1. If you are in Taiwan, you will visit the Bureau of Consular Affairs
-1. A final review is conducted by the Ministry of Interior
-1. Your Gold Card will be issued.
-    1. Claim it in Taiwan at the National Immigration Agency
-    1. Claim it at your nearest diplomatic post
+After completing the payment, you will receive an email at this point telling you to get your receipt.
+ You will need to print this out to collect your card, so do it now.
 
-## How long does the application take?
-A perfect application takes 30 days, if your supporting documents are accepted the first time around.
- If you are asked for tweaks to your supporting documents, expect 50-60 days.
+Still in the [portal](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card),
+ click "Download" and select "Receipt Download". Enter your application number and today's date.
 
-During the pandemic, we have seen 'normal' applications take as long as 80 days. Applicants who
-elected to pick their card up overseas are severely affected by the pandemic's impact on the postal
-network.
+The next three steps in the process are: Qualification Assessment, Identity Verification and Card Collection.
+During these steps, you can check the status if your application by logging in to the portal.
 
-## How do I find out the status of my application?
-Predominantly, you will find the status of your application by either logging in to the Gold Card
- Application Portal, or receiving email updates from the portal. However, if the status hasn't updated in
- a long time here's what you need to know:
-*  Who to contact changes depending on the status of your application.
-* The mostly lengthy status you will see is "Professional Review by Workforce Development Agency".
-    In this case, first, try the WDA, under the _Ministry of Labor for Employment Gold Card Permits
-    for Foreign Special Professionals_ on the master contact list. They will probably tell you that
-    the application is with the relevant ministry for your skill set and provide contact details. If not,
-    try to contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list
-* If your application is stuck on "Under inspection" after you already collected your passport,
-    contact the NIA - your card may already be printed.
+## Qualification Assessment
+🕑 2-4 weeks
+
+After a quick sanity check by the National Immigration Agency, your qualifications will be assessed.
+If you login to the portal to check your application status, you'll see it go from "Under Review"
+ to "待二審" (secondary inspection) to "Professional Review by Workforce Development Agency".
+
+Once your application reaches this stage, it will stay on this status for weeks.
+
+What's happening in the background is: 
+1. First, the Ministry of Labor will attempt to sign off on the work permit. If it can do this itself (eg you apply based on the salary criteria and provide the right documents), your application will be swift (one case took just two days).
+1. Most likely, the Ministry of Labor will need call in the appropriate Ministry (eg "Science and Technology) to assist. That Ministry will then create a custom panel of judges who are skilled in your area of application.
+
+This takes some time, and if you are skilled in a niche area expect the application to take longer than 30 days at this stage.
 
 
-## How do you get your physical card?
-Either at the National Immigration Agency service centres (in Taiwan) or at your local Taiwanese
- diplomatic post overseas. You selected where during your application.
+If the status in the portal hasn't updated in a long time first try contacting WDA, under the _Ministry of Labor for Employment Gold Card Permits for Foreign Special Professionals_ on the [master contact list](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24).
+ They will probably tell you that the application is with the relevant ministry for your skill set and provide contact details.
+ If not, try to contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list
 
 
-## What do I do if I'm asked to provide additional documents?
+### What do I do if I'm asked to provide additional documents?
 After a few weeks of tense wait, you may receive an email from niasys@immigration.gov.tw that says
 "After the examination by the department and the enterprise competent authority, the relevant information shall be made up.".
 
 Log in to the portal at:
 [https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card)
 
-Your application will be listed under "Application cases of which data to be supplemented", click View.
+Your application will be listed under "Application cases of which data to be supplemented", click "View".
 
 Up the top of the application will be a block of red text in Chinese and English. It will attempt
  to explain what additional documents are required. If it doesn't make sense, call the appropriate
 ministry contact under Qualification of Foreign Special Professionals on the master list. They'll be
  able to look up your application and provide more colour.
-
 
 Once you know which documents to upload, prepare to upload them as with your previous application.
  Additionally, prepare a short statement addressing how you have rectified the "Opinion
@@ -74,7 +68,7 @@ Once you know which documents to upload, prepare to upload them as with your pre
 _Important: Sometimes using English in the "Reply Comments" box will cause your application to fail
  to be submitted with a cryptic error._
 
-## I applied under a salary provision, but am being asked for additional documents unrelated to this. Why?
+### I applied under a salary provision, but am being asked for additional documents unrelated to this. Why?
 Don’t stress. This is normal. You’re applying under a financial requirement, but the relevant
  ministry still wants to vet your skills. Under some interpretations of the regulations, they
  are not supposed to do this, but here we are.
@@ -85,34 +79,3 @@ Gather up some documents that demonstrate you work in the industry and you’re 
  product that has your name on it. It’ll depend on what you’ve got or can create - but get into
  the mindset of the reviewer and aim to make it as easy as possible to understand why you are a
  talent. If you feel the need, write a cover letter for your application explaining your skills.
-
-## If I apply in Taiwan, where do I go to prove my identity?
-You must go to your local Bureau of Consular Affairs (BOCA). If you’re getting your passport
- vetted at Taipei’s BOCA/MOFA office, here’s a quick how-to. (Don’t worry, the ‘pinball’
- method - shuffling between volunteers - works well too).
-
-1. BOCA is open between 08:30 to 17:00 [here](https://goo.gl/maps/mFt8PBMCGnD2) (a few blocks from Shandao Temple Station, Exit 2)
-1. Enter the big pink building and go directly up the escalators to level 3
-1. On 3F, ignore the ticket machine immediately in front of you and turn right and right again to be at the “Authentication” area
-1. In the middle of the area, around counter 30, grab a ticket (if there is a problem, ask for help at the end counter - counter 28)
-1. Go to the designated counter when your number is up, surrender your passport and online
- application document, provide any details on upcoming travel, and receive your receipt.
-
-
-## Is there anything special I should do if I applied from overseas?
-
-If you live far from your local Taiwanese diplomatic post, it is recommended to call before going
- to give them a heads up. It’s highly likely that you’re the first person ever to go through this
- process in a particular office and giving them a day or two head start to let them call back to
- Taiwan and work out what to do when you arrive could be useful.
-
-
-
-## What is a "Resident Authorization Letter"?
-If you applied for your Gold Card from outside Taiwan but elected to collect your card
-on arrival, you may use the "Resident Authorization Letter" to enter Taiwan. After arriving,
- you may visit the National Immigration Agency to collect your card.
-
-## Do you need to fly to Taiwan immediately after approval?
-No. Some people took several months to prepare for their arrival. However, see the answer for
-[When does the gold card's validity begin?](/goldcard-holders-faq/validity/) to determine whether that affects you.

--- a/content/application-faq/application.md
+++ b/content/application-faq/application.md
@@ -5,117 +5,102 @@ weight: 3
 <!--- (c) Tom Fifield, licensed under a
 Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. -->
 
-## How to apply?
 Application is done online. Once you have determined how you are [qualified](/application-faq/qualifications/),
  gather the required documents:
 
 * digital copy of your passport
 * digital copy of your passport photo
-* locate your previous Taiwanese visa and residence permit (if any)
+* your previous Taiwanese visa and residence permit (if any)
 * dates of any times you worked in Taiwan
 * digital copies of all documents needed to support your application
 
-_Note: all digital copies need to be <1MB in size in image or PDF format. You may need to use an image resizing tool._
+> ⓘ  All digital copies need to be <1MB in size in image or PDF format.
 
-Second, go to the portal:
+## Starting your application
+🕑 10 minutes
+
+Go to the portal:
 
  [https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card)
 
 and click "I want to apply". Select "self application", click consent and create an account.
 
-To make a new application, click Application-->Application for Employment Gold Card --> New Application.
+> ⓘ  You don't need an employer to sponsor your application.
 
-Step through each of the sections, making sure you fill out each section before the ~5 minute timeout logs you out.
-Click save on each page to see if there are any errors detected.
+To make a new application, click "Application", select "Application for Employment Gold Card"
+ and then click New Application.
 
-_Note: the length of time you select for the card (eg 3 years) will determine its cost._
+You will be asked for your nationality and where you are applying from. 
+ Applying from overseas or from within Taiwan is the same process. It differs only in where you go
+ to hand in your passport (in Taiwan, or the local embassy), and overseas applicants
+ have the option of picking up their card from the local Taiwanese embassy.
 
-Eventually, view the preview and then hit submit!
+> ⚠️  This information cannot be changed later!
 
-_Note: you will receive an email at this point telling you to pay. If you didn't get it, check your email address was correct._
+> ⚠️  Ensure you select the right visa if applying from Taiwan. If you did not apply for
+> a visa to enter Taiwan, you are likely "visa-exempt" (the final category).
 
-You must then go through the payment steps in order for your application to be considered.
+You will now fill out three straightforward sections: Basic Data, Passport Data and Visa Application.
+Make sure to click "save" at the end of each section and fill each section out within 5 minutes to avoid being logged out.
 
-_Note: you will receive an email at this point telling you to get your receipt. Follow the steps to download it, and print it out - you will need it to collect your card._
+## Filling out Resident Information
+🕑 5 minutes
 
-## How long does the application take?
-A perfect application takes 30 days, if your supporting documents are accepted the first time
- around. If you are asked for tweaks to your supporting documents, expect 50-60 days.
-
-## Do I need to list an address in Taiwan on the application?
-It’s entirely normal and accepted to apply with no local address. Once you get a place to stay,
- you can (must) update the details on your card, [free of charge](/goldcard-holders-faq/life-in-taiwan/#what-happens-if-i-change-my-address).
-
- ## Can I use a temporary address?
-Yes, but we wouldn't recommend it. Important documents could be sent to that address and you might miss them.
-
-## Do I apply for the Gold Card personally, or should I ask my employer to do that?
-Generally you should apply personally. Employers can help with the process, but you do not need
- their sponsorship or support to apply for the card. Additionally, the card once issued contains
- an open work permit that allows you to work for any company. If someone is asking you for large sums
-of money to help with your gold card application, it could be a scam.
-
-## How do I decide the duration to apply for (1-3 years)?
-You select this during the application process. You could opt for a shorter duration if you have
+You must now select the duration for your card. You could opt for a shorter duration if you have
  concrete plans. Otherwise, it’s probably better to select the longest duration. There is no
  justification needed on how long you'd like to stay. This costs more, but delays the hassle of
  finding the next visa (or going through the gold card application process [/goldcard-holders-faq/validity/](again)).
 
-## Do you need to undergo a health check to apply for the Gold Card?
-We haven't heard of anyone to date who required a health check, so it's not a normal part of the
- process at least.
+You'll also be asked for a local address. It’s entirely normal and accepted to apply without one.
+ Once you get a place to stay, you can (must) update the details on your card,
+ [free of charge](/goldcard-holders-faq/life-in-taiwan/#what-happens-if-i-change-my-address). Only
+ fill an address out here if you're confident you will be able to receive important documents there.
 
-## What fees are involved in a Gold Card application?
-There is only one fee, which is paid through the Gold Card application portal. There are no separate visa or work permit fees.
+You must select where you will collect your card, there are two options to choose from:
+1. In Taiwan - generally faster, as your card does not need to be mailed overseas. You will use a
+ printed Residence Authorization Certificate to enter Taiwan, which might require some explanation
+ to your airline.
+1. At your local embassy - more convenient, as you can enter Taiwan with the process completed.
 
-The fees varies if you apply from Taiwan or overseas, the duration of the visa, and your nationality.
-You can check [the "Fees for Employment Gold Card" section of the application portal](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card).
+If you have information for any of the remaining fields, fill it in, or leave them blank if you dont.
+ Click "save" and "next step" to go to the Profession section.
 
-## I'm worried that my application will be rejected because I didn't attach enough documents.
-Don't stress. The authorities will ask for more documents if the ones you provided were not
+
+## Choosing Profession and Uploading Documents
+🕑 10 minutes
+
+Here you must choose the field and regulation which you selected in [Do I Qualify?](/application-faq/qualifications/).
+This can be changed later if necessary, but only after significant time has passed, so
+ be sure to choose the correct entry. Then, click "save" and "next step" to upload your documents.
+
+You must first upload a passport photo. Note that this has to be a proper passport photo that you would
+ use for a visa application - a selfie will be rejected.
+
+Next, you must upload a copy of your passport's bio page. You don't need to upload the whole thing,
+ or any of the stamp pages - just the page that shows your profile information.
+
+Finally, based on what regulation you are applying under you will need to upload required documents.
+ If you need hints on what to upload, use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/).
+
+Do not stress about your application being rejected because you didn't attach enough documents.
+The authorities will ask for more documents if the ones you provided were not
  sufficient. It’ll just extend the processing time by a couple of weeks to a month.
 
-## Do I need to have anything translated?
-If your documents are not in English or Chinese, they probably need to be translated.
+> ⚠️  If your documents are not in English or Chinese, they probably need to be translated.
 
-## Do I need to have anything certified?
-In general, no. However, if your documents are from the following countries, they probably need to be
- certified by [the Taiwan diplomatic post](https://www.mofa.gov.tw/en/OverseasOfficeLink.aspx?n=1A4D7D5A68ECF4B9&sms=A76B7230ADF29736)
- responsible for the country: Afghanistan, Algeria, Bengal,
- Bhutan, China, Cambodia, Cameroon, Cuba, Ghana, Indonesia, Iran, Iraq, Laos, Malaysia, Myanmar,
- Nepal, Niger, Nigeria, Pakistan, Senegal,  Somalia, Sri Lanka, Syria, Philippines, Thailand, Vietnam.
+> ⓘ  In general, your documents do not need to be certified, unless they are issued by
+> the following countries Afghanistan, Algeria, Bengal,
+> Bhutan, China, Cambodia, Cameroon, Cuba, Ghana, Indonesia, Iran, Iraq, Laos, Malaysia, Myanmar,
+> Nepal, Niger, Nigeria, Pakistan, Senegal,  Somalia, Sri Lanka, Syria, Philippines, Thailand, Vietnam.
+> Then, they probably need to be certified by the [nearest Taiwan diplomatic post](https://www.mofa.gov.tw/en/OverseasOfficeLink.aspx?n=1A4D7D5A68ECF4B9&sms=A76B7230ADF29736)
 
-## How is the application process different if I apply from overseas?
-Applying from overseas or from within Taiwan is the same process. It differs only in which unit
- verifies your passport (TECO or BOCA), and overseas applicants have the option of picking up
- their card from TECO.
 
-If you live far from your local Taiwanese diplomatic post, it is recommended to call before going
- to give them a heads up. It’s highly likely that you’re the first person ever to go through this
- process in a particular office and giving them a day or two head start to let them call back to
- Taiwan and work out what to do when you arrive could be useful.
+Eventually, view the preview and then hit submit!
 
-## Should I upload my entire passport?
-You don't need to upload your entire passport. Only the bio page is necessary.
+
 
 ## Who can I talk to about this?
-You're in for some serious luck here! The Gold Card comes with some direct contacts who are
- high level and exceptionally helpful. However, first it is critical to understand that this
- program is a collaboration of disparate Government departments who aren't necessarily in constant
-communication with each other. You will need to choose a department to contact depending on the
- stage of your application.
-
-
 The master list of contacts is [found here](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24).
 
-If you'd like to discuss:
-* whether you should apply eg benefits of the program, vague/early questions
-    - Read the [Foreign Talent Act website](https://foreigntalentact.ndc.gov.tw/en/Default.aspx)
-    - Ask [Contact Taiwan](https://www.contacttaiwan.tw/main/index.aspx?lang=2#), particularly look out for their events with invited speakers from NIA. They are a Government-funded organisation whose mission is to help you find a job. They'll direct you to the right place
-* the online application portal, eg errors, ambiguous fields: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special Professionals_ on the master list
-* skill qualification, eg required documents, why your initial set of documents was rejected: Contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list
-* status of your application eg where it is now, why it's taking so long: See "How do I find out the status of my application?"
-* visas for your spouse/family: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special Professionals_ on the master list
-* income tax reduction eg whether you qualify, how it works: the NIA can sometimes provide some basic information about this, otherwise contact the Ministry of Finance under _Reduction or Exemption of Income Tax of Foreign Special Professionals_ on the master list
-* A particular agency's implementation of the program eg make an appeal or complaint, talk to "whoever's in charge": Contact the National Development Council.
-
+- If something is wrong with the online application portal, eg errors, ambiguous fields: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special Professionals_ on the master list
+- If you don't know what documents to apply with, or which regulation to choose, contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list

--- a/content/application-faq/application.md
+++ b/content/application-faq/application.md
@@ -79,7 +79,7 @@ You must first upload a passport photo. Note that this has to be a proper passpo
 Next, you must upload a copy of your passport's bio page. You don't need to upload the whole thing,
  or any of the stamp pages - just the page that shows your profile information.
 
-Finally, based on what regulation you are applying under you will need to upload required documents.
+Finally, based on the regulation you are applying under you will need to upload required documents.
  If you need hints on what to upload, use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/).
 
 Do not stress about your application being rejected because you didn't attach enough documents.
@@ -100,7 +100,7 @@ Eventually, view the preview and then hit submit!
 
 
 ## Who can I talk to about this?
-The master list of contacts is [found here](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24).
+If you need help, the master list of contacts is [found here](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24).
 
-- If something is wrong with the online application portal, eg errors, ambiguous fields: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special Professionals_ on the master list
+- If something is wrong with the online application portal, eg errors, ambiguous fields: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special Professionals_ on the master list or use the number on the bottom of the application portal
 - If you don't know what documents to apply with, or which regulation to choose, contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list

--- a/content/application-faq/qualifications.md
+++ b/content/application-faq/qualifications.md
@@ -19,12 +19,8 @@ No. Some industries have a category where applicants with a salary greater than 
 
 ## I currently live in Taiwan, can I apply for the Gold Card?
 Yes. You can apply from anywhere, even within Taiwan.
-
-## I have an ARC, can I apply for the Gold Card?
-Yes, it will replace your ARC.
-
-## I have a tourist visa in Taiwan, can I apply for the Gold Card?
-Yes.
+If you have an ARC, you can still apply, the Gold Card will replace you ARC.
+If you have a tourist visa, the Gold Card will replace your tourist visa.
 
 ## I'm a digital nomad / remote worker, is this card suitable for me? Can I be self-employed?
 Yes, this card is perfect for you, since it contains an open work permit that allows you to work for any

--- a/content/application-faq/qualifications.md
+++ b/content/application-faq/qualifications.md
@@ -1,16 +1,15 @@
 ---
-title: "Qualifications"
+title: "Do I qualify?"
 weight: 2
 ---
 <!--- (c) Tom Fifield, licensed under a
 Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. -->
 
-## Do I qualify?
 In order to qualify for an Employment Gold Card your skills must be related to one of eight areas:
  Science and Technology, Economics, Education, Culture and Art, Sport, Finance, Law and Architecture.
  You must select which single ministry is most relevant, and in most cases also select a specific entry in
  the list of that qualifications in that particular area for your application.
-Use the [Gold Card Qualification Wizard](https://visafinder.tw/gold-card-qualification/) to find the relevant
+Use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/) to find the relevant
  choices for you.
 
 ## Do I need to have a high salary to apply for a Gold Card?
@@ -34,7 +33,7 @@ Yes, this card is perfect for you, since it contains an open work permit that al
 
 ## Is there a "general" application category or must I select a specific industry? 
 There is no "general" application category. You must select a single ministry to assess your skills.
-Use the [Gold Card Qualification Wizard](https://visafinder.tw/gold-card-qualification/) to find suggestions.
+Use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/) to find suggestions.
 
 ## Does my professional services/sole proprietor/dividend income count towards the salary requirement for Gold Card application?
 Generally not, but it depends. The document requirements to prove an Article 1 ("salary")

--- a/content/application-faq/what-is-taiwan-gold-card.md
+++ b/content/application-faq/what-is-taiwan-gold-card.md
@@ -19,6 +19,11 @@ Qualification is based on an asssessment of your professional skills, you don't 
 A perfect application takes 30 days, if your supporting documents are accepted the first time
  around. If you are asked for tweaks to your supporting documents, expect 50-60 days.
 
+> During the pandemic, we have seen 'normal' applications take as long as 80 days. Applicants who
+ elected to pick their card up overseas are severely affected by the pandemic's impact on the postal
+network.
+<!---TODO revise in a few months.-->
+
 ## Do I apply for the Gold Card personally, or should I ask my employer to do that?
 Generally you should apply personally. Employers can help with the process, but you do not need
  their sponsorship or support to apply for the card. Additionally, the card once issued contains

--- a/content/application-faq/what-is-taiwan-gold-card.md
+++ b/content/application-faq/what-is-taiwan-gold-card.md
@@ -1,11 +1,48 @@
 ---
-title: "What is Taiwan Employment Gold Card?"
+title: "What is the Gold Card?"
 weight: 1
-draft: true
 # Let's make sure we agree on this: https://github.com/taiwangoldcard/website/pull/23
 ---
 
-Taiwan Employment Gold Card is a special visa launched in 2018 to attract "special" talents in Taiwan. 
-It gives you the right to stay and work in Taiwan from 1 year up to 3 years (renewable). You'll be able to work for any company, start a new business, have great tax incentives,  benefit Taiwan healthcare system, and bring your family with you.
+The Taiwan Employment Gold Card is a combined visa, work permit and residence permit launched in 2018
+ to attract professional talent in Taiwan. The card gives you the right to stay and work in Taiwan for
+ 1 year to 3 years, and you can apply online without sponsorship. The card comes with open
+ work rights, so you may work for any (or multiple) company in Taiwan or start your own business.
+ You can bring your family with you, and visitor rights for parents and grandparents are also included.
+ There are tax incentives for cardholders with high salaries.
 
-The application is online, and straight forward. Approbation is based on your existing skills. You don't need  to already have a job or any company to sponsor you. The visa costs, depending of your nationality and the duration of the visa, from USD100 to USD310.
+Qualification is based on an asssessment of your professional skills, you don't need to have already
+ secured a job in Taiwan. The Gold Card costs between USD100 and USD310 depending on your nationality and
+ the duration of your card.
+
+## How long does the application take?
+A perfect application takes 30 days, if your supporting documents are accepted the first time
+ around. If you are asked for tweaks to your supporting documents, expect 50-60 days.
+
+## Do I apply for the Gold Card personally, or should I ask my employer to do that?
+Generally you should apply personally. Employers can help with the process, but you do not need
+ their sponsorship or support to apply for the card. Additionally, the card once issued contains
+ an open work permit that allows you to work for any company. If someone is asking you for large sums
+of money to help with your gold card application, it could be a scam.
+
+## What fees are involved in a Gold Card application?
+There is only one fee, which is paid through the Gold Card application portal. There are no separate visa or work permit fees.
+
+The fees varies if you apply from Taiwan or overseas, the duration of the visa, and your nationality.
+You can check [the "Fees for Employment Gold Card" section of the application portal](https://coa.immigration.gov.tw/coa-frontend/four-in-one/entry/golden-card).
+<!---TODO add fee reference.-->
+
+## Who can I talk to about this?
+If you'd like to discuss: whether you should apply, benefits of the program, or any early questions:
+- Read the [Foreign Talent Act website](https://foreigntalentact.ndc.gov.tw/en/Default.aspx)
+- Ask [Contact Taiwan](https://www.contacttaiwan.tw/main/index.aspx?lang=2#). They are a Government-funded organisation whose mission is to help you find a job. They'll direct you to the right place.
+
+Otherwise, look at the [master contact list](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24) to talk about:
+- tax incentives: the NIA can sometimes provide some basic information about this, otherwise contact the Ministry of Finance under _Reduction or Exemption of Income Tax of Foreign Special Professionals_ on the master list
+- visas for your spouse/family: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special P    rofessionals_ on the master list
+
+
+## Do you need to undergo a health check to apply for the Gold Card?
+We haven't heard of anyone to date who required a health check, so it's not a normal part of the
+ process at least.
+


### PR DESCRIPTION
FAQ style isn't the best answer for instructional content that follows a process.

This restructuring of the site's Application content is designed to align with the steps that someone applying for a gold card will take. Check out issue #42 to see where the content was merged into, but the general changes are:

1. New section for explaining the gold card and FAQ about the program as a whole
1. Spread out massive pieces of content like "How to Apply" and "Who to Contact" into smaller pieces under headings that match steps in the application process.
1. New section for the steps/questions that happen "After passing skill assessment"
1. Merging a few questions and using blockquotes to call out important points that were previously questions.

General structure now:
* What is the Gold Card?
* Do I qualify?
* The Gold Card Application
    * Start your application (combines all of: Creating an account, logging in and starting a new application, Identity and Visa details, terms and conditions, Basic Data, Passport Data and Visa Application)
    * Resident Information
    * Profession Information and Document Upload (NB: categories combined since they are strongly linked)
* After Submitting your application (combines Submit Application->Under Review-> 待二審
 ->Professional Review by Workforce Development Agency->Supplementary Document Submission)
    * Qualification Assessment
* After passing skill assessment (combines Passport Submission by Bureau of Consular Affairs or Overseas Missions of R.O.C.->Under Inspection->Application Approved->IC Card in Process->Collect card) 
    * Identity Verification
    * Card Collection


Fixes #42 