### PR TITLE
Add a note about the wrong visa type error message

### DIFF
--- a/content/application-faq/after-submitting-application.md
+++ b/content/application-faq/after-submitting-application.md
@@ -47,6 +47,24 @@ If the status in the portal hasn't updated in a long time first try contacting W
  They will probably tell you that the application is with the relevant ministry for your skill set and provide contact details.
  If not, try to contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list
 
+### Why was my application was rejected with a message about visa type?
+You probably received an error message that looks like this: "申請人以免籤證入境，申請時身份類別選擇錯誤，不予許可"
+ This translates to "You entered Taiwan 'visa-exempt', but when applying you selected the wrong
+ visa/identity category, application refused."
+
+Don't stress. You will have to make a new application, but your old one can be refunded.
+ When [starting an application](/application-faq/application/#starting-your-application) from inside
+ Taiwan, you will be asked what visa you hold. A common mistake is to select
+ "I entered R.O.C. with a visa of which the duration of stay is more than 60 days" because you have a
+ stamp in your passport that says "90 days". However, unless you explicitly applied for a visa to
+ come to Taiwan, you are probably here under "visa exempt" entry, which was another item on that list.
+
+The NIA looked up your visa status, found it incorrect, and rejected your application.
+ What you need to do now is:
+1. Call NIA, using the phone number on the bottom of the application portal or the "Ministry of Interior" on the [official contact list](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24), explain what happened and ask for a refund.
+1. Make a new application
+
+
 
 ### What do I do if I'm asked to provide additional documents?
 After a few weeks of tense wait, you may receive an email from niasys@immigration.gov.tw that says

--- a/content/application-faq/after-submitting-application.md
+++ b/content/application-faq/after-submitting-application.md
@@ -47,7 +47,7 @@ If the status in the portal hasn't updated in a long time first try contacting W
  They will probably tell you that the application is with the relevant ministry for your skill set and provide contact details.
  If not, try to contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list
 
-### Why was my application was rejected with a message about visa type?
+### Why was my application rejected with a message about visa type?
 You probably received an error message that looks like this: "申請人以免籤證入境，申請時身份類別選擇錯誤，不予許可"
  This translates to "You entered Taiwan 'visa-exempt', but when applying you selected the wrong
  visa/identity category, application refused."


### PR DESCRIPTION
Adds a note about an application rejection scenario where people
 select the wrong visa type, which has happened to applicants a
 few times recently.

Fixes #29