### PR TITLE
Add disclaimer to protect contributors

### DIFF
--- a/content/terms.md
+++ b/content/terms.md
@@ -1,0 +1,38 @@
++++
+title = "Disclaimer and Terms of Use"
++++
+
+{{< block "grid-2 mt-2 homepage-div" >}}
+{{< column >}}
+
+Taiwan Gold Card is a community website maintained by the Gold Card community. We are not
+ affiliated, associated, authorized, endorsed by, or in any way officially connected with
+ any governments, its departments or agencies. Official information can be found on the
+ official websites.
+
+The information herein is for general informational purpose only. We make no representation
+ or warranty of any kind, express or implied, regarding the accuracy, adequacy, validity,
+ reliability, availability or completeness of any information.
+
+Before taking any actions based upon such information, we encourage you to consult with
+ the appropriate professionals. We do not provide any kind of advice.
+
+Under no circumstance shall we have any liability to you for any loss or damage of any kind
+ incurred as a result of the use of this website or reliance on any information provided on 
+this website. Your use of this website and your reliance on any information on this website 
+is solely at your own risk.
+
+The content on this website is protected by international copyright and owned by the Gold
+ Card community. Use of this website means acceptance of all terms of use and disclaimer,
+ subject to change without notice.
+
+
+
+{{< /column >}}
+
+{{< column >}}
+![Taiwan](/images/taiwan-unsplash.jpeg)
+
+
+{{< /column >}}
+{{< /block >}}

--- a/themes/compose/layouts/partials/footer.html
+++ b/themes/compose/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.enableCopyright | default true }}
 <footer class="mt-2 pt-2 pb-2">
   <div class="wrap">
-    <p>taiwangoldcard.com is maintained by Gold Card Holders. We are not affiliated with any government departments - <a href="/about">About us</a> </p>
+    <p><a href="/about">About us</a> | <a href="/terms">Terms</a> | taiwangoldcard.com is maintained by Gold Card Holders. We are not affiliated with any government departments.</p>
   </div>
 </footer>
 {{ end }}


### PR DESCRIPTION
Add dedicated Disclaimer and Terms of Use page to host the
 recommended content we recieved from lawyers.

Small update to the footer to include the link.

Fixes #32