### PR TITLE
Fix homepage styling

### DIFF
--- a/themes/compose/assets/sass/main.sass
+++ b/themes/compose/assets/sass/main.sass
@@ -69,6 +69,7 @@
         display: table-cell
         padding-right: 10px
         font-style: italic
+        white-space: nowrap;
 
 .blink
   animation: blinkAnimation 500ms linear 2;

--- a/themes/compose/assets/sass/main.sass
+++ b/themes/compose/assets/sass/main.sass
@@ -46,8 +46,8 @@
 
 .homePicture
     grid-area: picture
-    padding: 0
-    margin: 0
+    padding: 10px
+    margin: 10px
 
 .latestNews
     grid-area: news


### PR DESCRIPTION
Related to #60

**Changes**

1. Add **white-space: nowrap** for dateTime
2. Add margin and padding (10px) to homePicture

**Result (Before & After)**
![imgonline-com-ua-twotoone-CVBBpvsGfA](https://user-images.githubusercontent.com/9074112/87615951-7bfc6c80-c746-11ea-9f15-ea6841a4fc01.jpg)
