### PR TITLE
Display "Gold Card News" dynamically

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -44,6 +44,10 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
   description = "We are a strong community of professionals with Taiwan Gold Card visa. We happily help newcomers and support each other within the Gold Card community"
   title = "Taiwan Gold Card | Taiwan Foreign Talent Community"
 
+  # Integrate Javascript files by adding the url to the external assets or by
+  # linking local files with their path relative to the static folder, e.g. "js/myscript.js"
+  customJS  = ["js/news_display.js"]
+
   time_format_blog = "Monday, January 02, 2006"
   time_format_default = "January 2, 2006"
   [params.logo]

--- a/content/_index.md
+++ b/content/_index.md
@@ -26,17 +26,8 @@ title = "Taiwan Gold Card"
 {{< button "goldcard-holders-faq/" "Resources for GoldCard holders" >}}
 {{< /section >}}
 
-{{< section "latestNews" >}}
-
-## Gold Card News
-
-- <time datetime="2020-06-30">2020-06-30</time> [Almost 900 gold cards issued!](https://foreigntalentact.ndc.gov.tw/en/News_Content.aspx?n=F0746484B877D582&s=91B121FE3FA7C24D)
-- <time datetime="2020-06-12">2020-06-12</time> [President Tsai Promotes Gold Card](https://english.president.gov.tw/News/6008)
-- <time datetime="2020-06-05">2020-06-05</time> [Goldcard holder: Tomáš řízek illustration exhibition](https://99dac.com/exhibition-detail.php?id=140)
-- <time datetime="2020-06-05">2020-05-27</time> [Goldcard holder: Starting an eye yoga career](https://meet.bnext.com.tw/intl/articles/view/46488)
-- <time datetime="2020-06-05">2020-04-13</time> [Tax payment has been extended to June 30th 2020](https://home.kpmg/us/en/home/insights/2020/04/tnf-taiwan-tax-return-tax-payment-deadlines-extended-covid-19.html)
-
-{{< /section >}}
+[//]: # "latestNews is modified by news_display.js"
+{{< section "latestNews" >}}{{< /section >}}
 
 {{< section "homePicture" >}}
 

--- a/content/news.md
+++ b/content/news.md
@@ -1,0 +1,7 @@
+## Gold Card News
+
+- <time datetime="2020-06-30">2020-06-30</time> [Almost 900 gold cards issued!](https://foreigntalentact.ndc.gov.tw/en/News_Content.aspx?n=F0746484B877D582&s=91B121FE3FA7C24D)
+- <time datetime="2020-06-12">2020-06-12</time> [President Tsai Promotes Gold Card](https://english.president.gov.tw/News/6008)
+- <time datetime="2020-06-05">2020-06-05</time> [Goldcard holder: Tomáš řízek illustration exhibition](https://99dac.com/exhibition-detail.php?id=140)
+- <time datetime="2020-06-05">2020-05-27</time> [Goldcard holder: Starting an eye yoga career](https://meet.bnext.com.tw/intl/articles/view/46488)
+- <time datetime="2020-06-05">2020-04-13</time> [Tax payment has been extended to June 30th 2020](https://home.kpmg/us/en/home/insights/2020/04/tnf-taiwan-tax-return-tax-payment-deadlines-extended-covid-19.html)

--- a/static/js/news_display.js
+++ b/static/js/news_display.js
@@ -18,7 +18,8 @@ function filterNewsList(selectorName, limitContent) {
     $(selectorName).html(function() {
         let li = $(this).find("li");
         $(li).each(function(index, value){
-            if (index < limitContent) filteredNewsList.push(value);
+            if (index >= limitContent) return false;
+            filteredNewsList.push(value);
         })
     });
 

--- a/static/js/news_display.js
+++ b/static/js/news_display.js
@@ -1,0 +1,38 @@
+// JS for displaying latestNews
+$(document).ready(function() {
+    var limitContent = 8;
+    var selectorName = ".latestNews";
+    var filteredNewsList = filterNewsList(selectorName, limitContent);
+    var ulId = "lastestNewsList";
+    displayNewsList(selectorName, filteredNewsList, ulId, function() {
+        $("#" + ulId).append('<a href="news" target="_blank" rel="noopener">Read More</a>');
+    });
+})
+
+// Select the first n of news list
+function filterNewsList(selectorName, limitContent) {
+    if (typeof limitContent !== "number" || limitContent === null)
+        return;
+
+    let filteredNewsList = [];
+    $(selectorName).html(function() {
+        let li = $(this).find("li");
+        $(li).each(function(index, value){
+            if (index < limitContent) filteredNewsList.push(value);
+        })
+    });
+
+    return filteredNewsList;
+}
+
+// Display news list
+function displayNewsList(selectorName, newsList, ulId, objCallBack) {
+    $(selectorName + " > ul").attr("id", ulId); // add id to unordered list
+    $("#" + ulId).empty(); // clear old ul
+    $.each(newsList, function(key, value) {
+        $("#" + ulId).append(value);
+    });
+
+    if (typeof objCallBack !== "undefined" && objCallBack !== null)
+        objCallBack();
+}

--- a/static/js/news_display.js
+++ b/static/js/news_display.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
     var filteredNewsList = filterNewsList(selectorName, limitContent);
     var ulId = "lastestNewsList";
     displayNewsList(selectorName, filteredNewsList, ulId, function() {
-        $("#" + ulId).append('<a href="news" target="_blank" rel="noopener">Read More</a>');
+        $("#" + ulId).append('<li><a href="news" target="_blank" rel="noopener">Read More</a></li>');
     });
 })
 

--- a/themes/compose/assets/sass/main.sass
+++ b/themes/compose/assets/sass/main.sass
@@ -10,13 +10,13 @@
 
 
 .home 
-    display: grid;
+    display: grid
     grid-template-columns: 30% 20% 20% 30%
     grid-template-rows: auto
     grid-template-areas: "picture picture picture news" "left-question left-question right-question right-question" 
 
     @media (max-width: $tabletBreakPoint)
-        display: grid;
+        display: grid
         grid-template-columns: auto
         grid-template-rows: auto
         grid-template-areas: "news" "picture" "left-question" "right-question" 
@@ -24,7 +24,7 @@
 
 .newApplicant
     grid-area: left-question
-    margin-top: 30px;
+    margin-top: 30px
     @media (max-width: $phoneBreakPoint)
         a.button
             width: 100%
@@ -33,7 +33,7 @@
 
 .existingApplicant
     grid-area: right-question
-    margin-top: 30px;
+    margin-top: 30px
     p
         display: inline
     a.button
@@ -58,21 +58,21 @@
         margin-top: 0px
     ul
         display: table
-        padding-left: 0px;
+        padding-left: 0px
     li
         display: table-row
         padding-bottom: 15px
         a
             display: table-cell
-            padding-bottom: 5px;
+            padding-bottom: 5px
     time
         display: table-cell
         padding-right: 10px
         font-style: italic
-        white-space: nowrap;
+        white-space: nowrap
 
 .blink
-  animation: blinkAnimation 500ms linear 2;
+  animation: blinkAnimation 500ms linear 2
 
 @keyframes blinkAnimation
   50%

--- a/themes/compose/layouts/partials/scripts.html
+++ b/themes/compose/layouts/partials/scripts.html
@@ -9,3 +9,10 @@
 
 {{- $bundle := slice $lunr $search $main | resources.Concat "js/bundle.js" | resources.Minify | resources.Fingerprint "sha512" }}
 <script src = '{{ $bundle.Permalink }}'></script>
+
+<!-- Integrate custom JS -->
+{{ range $val := $.Site.Params.customJS }}
+    {{ if gt (len $val) 0 }}
+        <script src="{{ $val }}"></script>
+    {{ end }}
+{{ end }}

--- a/themes/compose/layouts/shortcodes/section.html
+++ b/themes/compose/layouts/shortcodes/section.html
@@ -1,5 +1,9 @@
 {{- $sectionName := .Get 0 -}}
 
 <section class="section {{- with $sectionName }} {{ . }}{{ end }}">
-  {{- .Inner | markdownify -}}
+  {{ if (eq $sectionName "latestNews") }}
+      {{- readFile "news.md" | markdownify -}}
+  {{ else }}
+      {{- .Inner | markdownify -}}
+  {{ end }}
 </section>


### PR DESCRIPTION
#64 

**Changes**

- Gold Card News section is now displayed based on a limit given (default = 8 items)
- The written content is now rendered from news.md
- All news can be viewed from **Read More** as a separate page
- Remove unnecessary semicolons from SASS

**Examples**
![image](https://user-images.githubusercontent.com/9074112/88039734-88375e00-cb7a-11ea-826c-fd8153906df1.png)
![image](https://user-images.githubusercontent.com/9074112/88039755-908f9900-cb7a-11ea-8161-e0baf07e2ec1.png)
