### PR TITLE
Add a note about 1099 form salary qualification

### DIFF
--- a/content/application-faq/qualifications.md
+++ b/content/application-faq/qualifications.md
@@ -37,7 +37,8 @@ Generally not, but it depends. The document requirements to prove an Article 1 (
  application all talk about "...verifying salary or income tax payment related to employment...".
  The most commonly accepted documents appear to be withholding tax statements from employers and
  income tax returns from a tax authority. Bank statements are generally not sufficient. If you
- don't have salary-based compensation for your employment, we recommend [calling ahead](/application-faq/application/#who-can-i-talk-to-about-this).
+ don't have salary-based compensation for your employment, we recommend [calling ahead](/application-faq/application/#who-can-i-talk-to-about-this). You may be able to make an argument if your freelance income looks a lot like
+salary (eg "7 Nonemployee Compensation" on a 1099 form from the USA).
 
 ## Is there an age restriction? 
 Not really. However it is expected that gold card holders will have at least five years of work experience.


### PR DESCRIPTION
We've seen a case where an applicant qualified based on the number
in the USA 1099 tax form that was labelled "nonemployee
compensation". Add a note to the freelance question to share this.