### PR TITLE
Update list of contributors

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -40,7 +40,7 @@ Content and the underlying site is contributed by a volunteer community that you
 {{< column >}}
 ![Taiwan](/images/taiwan-unsplash.jpeg)
 
-The following people have contributed to this site: Alvin, Eric Khun, Ian Sinnott, Jonathan Liao, Philip Bergvist, Tom Fifield.
+The following people have contributed to this site: Alvin, Audrey Tang, Colum Brolly, Cuan-Bo Pong, Eric Khun, Ian Sinnott, Jonathan Liao, Nuttaphat Arunoprayoch, Philip Bergvist, Tom Fifield.
 
 {{< /column >}}
 {{< /block >}}

--- a/content/about.md
+++ b/content/about.md
@@ -40,7 +40,7 @@ Content and the underlying site is contributed by a volunteer community that you
 {{< column >}}
 ![Taiwan](/images/taiwan-unsplash.jpeg)
 
-The following people have contributed to this site: Alvin, Audrey Tang, Colum Brolly, Cuan-Bo Pong, Eric Khun, Ian Sinnott, Jonathan Liao, Nuttaphat Arunoprayoch, Philip Bergvist, Tom Fifield.
+The following people have contributed to this site: Alvin, Antoine Scemama, Audrey Tang, Colum Brolly, Cuan-Bo Pong, Eric Khun, Ian Sinnott, Jonathan Liao, Nuttaphat Arunoprayoch, Philip Bergvist, Tom Fifield.
 
 {{< /column >}}
 {{< /block >}}


### PR DESCRIPTION
We have been fortunate to have a number of new contributors in
 recent weeks. This patch adds their names to the about page.

* Audrey Tang, who fixed our configuration
* Colum Brolly, who fixed the content in several places
* Cuan-Bo Pong, who provided the legal terms
* Nuttaphat Arunoprayoch, who fixed the homepage layout,
  tested and updated the deployment instructions,
  and added a dynamic news section

Thank you to all for your contributions!