### PR TITLE
Add Gold Card community gathering (for past and future events)

### DIFF
--- a/content/news.md
+++ b/content/news.md
@@ -1,6 +1,8 @@
 ## Gold Card News
-
+- <time datetime="2020-08-14">2020-08-14</time> [Gold Card Community Gathering](https://photos.app.goo.gl/Li6j3vvBJHTFs1nJ9)
 - <time datetime="2020-08-01">2020-08-01</time> [Goldcard holder: Alvaro Trugeda art exhibition](https://www.bauyu.com/)
+- <time datetime="2020-07-02">2020-07-02</time> [Gold Card Community Gathering](https://photos.app.goo.gl/ZRfWhHkVfCTPKCgy8)
+- <time datetime="2020-06-28">2020-06-28</time> [Gold Card Community Gathering](https://photos.app.goo.gl/3U6iwC2TVcrvqnMe6)
 - <time datetime="2020-06-30">2020-06-30</time> [Almost 900 gold cards issued!](https://foreigntalentact.ndc.gov.tw/en/News_Content.aspx?n=F0746484B877D582&s=91B121FE3FA7C24D)
 - <time datetime="2020-06-12">2020-06-12</time> [President Tsai Promotes Gold Card](https://english.president.gov.tw/News/6008)
 - <time datetime="2020-06-05">2020-06-05</time> [Goldcard holder: Tomáš řízek illustration exhibition](https://99dac.com/exhibition-detail.php?id=140)

--- a/content/news.md
+++ b/content/news.md
@@ -1,8 +1,7 @@
 ## Gold Card News
-- <time datetime="2020-08-14">2020-08-14</time> [Gold Card Community Gathering](https://photos.app.goo.gl/Li6j3vvBJHTFs1nJ9)
+- <time datetime="2020-08-14">2020-08-14</time> [Community Gathering](https://photos.app.goo.gl/Li6j3vvBJHTFs1nJ9)
 - <time datetime="2020-08-01">2020-08-01</time> [Goldcard holder: Alvaro Trugeda art exhibition](https://www.bauyu.com/)
-- <time datetime="2020-07-02">2020-07-02</time> [Gold Card Community Gathering](https://photos.app.goo.gl/ZRfWhHkVfCTPKCgy8)
-- <time datetime="2020-06-28">2020-06-28</time> [Gold Card Community Gathering](https://photos.app.goo.gl/3U6iwC2TVcrvqnMe6)
+- <time datetime="2020-07-02">2020-07-02</time> [Community Gathering](https://photos.app.goo.gl/ZRfWhHkVfCTPKCgy8)
 - <time datetime="2020-06-30">2020-06-30</time> [Almost 900 gold cards issued!](https://foreigntalentact.ndc.gov.tw/en/News_Content.aspx?n=F0746484B877D582&s=91B121FE3FA7C24D)
 - <time datetime="2020-06-12">2020-06-12</time> [President Tsai Promotes Gold Card](https://english.president.gov.tw/News/6008)
 - <time datetime="2020-06-05">2020-06-05</time> [Goldcard holder: Tomáš řízek illustration exhibition](https://99dac.com/exhibition-detail.php?id=140)


### PR DESCRIPTION
Hey @taiwangoldcard/goldies  , 

How does that feel to add the past and upcoming events in the website ?
It shows we are active and will incentive people gold card holders to join the community .
The links point to   a Google photos album. 


<img width="1341" alt="Screenshot 2020-08-15 at 10 58 51" src="https://user-images.githubusercontent.com/3368263/90304045-606fb780-dee6-11ea-9df6-f6ee59111f19.png">