### PR TITLE
Fixes #45

### DIFF
--- a/themes/compose/assets/js/index.js
+++ b/themes/compose/assets/js/index.js
@@ -476,5 +476,9 @@ $(function() {
 
 });
 
+function revealSideBar() {
+  $("aside.aside.hidden").removeClass("hidden");
+}
 
+window.addEventListener("DOMContentLoaded", revealSideBar);
 window.addEventListener('load', loadActions());

--- a/themes/compose/assets/sass/_utils.sass
+++ b/themes/compose/assets/sass/_utils.sass
@@ -49,3 +49,6 @@
 
 .active
   color: var(--theme)
+
+.hidden
+  visibility: hidden

--- a/themes/compose/layouts/partials/sidebar.html
+++ b/themes/compose/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<aside class="aside">
+<aside class="aside hidden">
   {{- template "tree" (dict "page" . "section" .FirstSection)  }}
   {{- define "tree" }}
   {{- $section := .section }}


### PR DESCRIPTION

![taiwangoldcard](https://user-images.githubusercontent.com/977460/91332528-e6e99a80-e7fe-11ea-95f0-9ad08b5421fe.gif)

Fixes - https://github.com/taiwangoldcard/website/issues/45

I made the sidebar hidden until the JS has fully loaded. Mitigates that FOUC. 