### PR TITLE
Move jquery to scripts section to avoid blocking

### DIFF
--- a/themes/compose/layouts/partials/head.html
+++ b/themes/compose/layouts/partials/head.html
@@ -13,9 +13,6 @@
 <meta name="theme-color" content="#ffffff">
 
 <!-- <link rel="stylesheet" href="https://unicons.iconscout.com/release/v2.1.9/css/unicons.css"> -->
-
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
-
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 
 {{- partial "opengraph" . }}

--- a/themes/compose/layouts/partials/scripts.html
+++ b/themes/compose/layouts/partials/scripts.html
@@ -1,3 +1,5 @@
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
+
 {{- $lunrPath := "js/lunr.js" }}
 {{- $lunr := resources.Get $lunrPath | resources.ExecuteAsTemplate $lunrPath . }}
 


### PR DESCRIPTION
[Lighthouse](https://developers.google.com/web/tools/lighthouse) report:

<img width="774" alt="Screenshot 2020-08-27 at 6 23 53 PM" src="https://user-images.githubusercontent.com/977460/91431522-10540600-e893-11ea-8b54-ee839dba45e5.png">

jQuery script is currently located in the `head` block, therefore resulting in a render block. I moved this down to the bottom where all scripts are running. 

Before:
<img width="1211" alt="Screenshot 2020-08-27 at 6 24 11 PM" src="https://user-images.githubusercontent.com/977460/91431623-35487900-e893-11ea-9bc0-f6e50999d85e.png">

After:
<img width="1140" alt="Screenshot 2020-08-27 at 6 29 29 PM" src="https://user-images.githubusercontent.com/977460/91431685-4abda300-e893-11ea-8e33-ee6e09e3a513.png">

Lets see if it speeds up our site. 