### PR TITLE
Remove jQuery

### DIFF
--- a/themes/compose/assets/js/index.js
+++ b/themes/compose/assets/js/index.js
@@ -419,65 +419,9 @@ function loadActions() {
   })();
 }
 
-$(function() {
-
-    var hasClicked = false;
-
-    // hide bar when clicking on a menu item
-    $(".toc_item a").on('click', function(event) {
-      hasClicked = true;
-      if ($(window).scrollTop() !== 0) {
-        $('.nav_header').removeClass('nav-down').addClass('nav-up');
-      }
-    });
-
-      // Hide Header on on scroll down
-      var didScroll;
-      var lastScrollTop = 0;
-      var delta = 100;
-      var navbarHeight = $('.nav_header').outerHeight();
-      $(window).scroll(function(event){
-          didScroll = true;
-      });
-
-      setInterval(function() {
-          if (didScroll) {
-              hasScrolled();
-              didScroll = false;
-              hasClicked = false;
-          }
-      }, 500);
-
-      function hasScrolled() {
-          var st = $(this).scrollTop();
-
-          // Make sure they scroll more than delta
-          if(Math.abs(lastScrollTop - st) <= delta)
-              return;
-
-          // If they scrolled down and are past the navbar, add class .nav-up.
-          // This is necessary so you never see what is "behind" the navbar.
-          if (st > lastScrollTop && st > navbarHeight){
-              // Scroll Down
-              $('.nav_header').removeClass('nav-down').addClass('nav-up');
-          } else {
-              // Scroll Up
-              if(st + $(window).height() < $(document).height()) {
-                if (hasClicked != true) {
-                  $('.nav_header').removeClass('nav-up').addClass('nav-down');
-                }
-              }
-          }
-          lastScrollTop = st;
-      }
-
-
-
-
-});
-
 function revealSideBar() {
-  $("aside.aside.hidden").removeClass("hidden");
+  const sideBar = document.querySelector("aside.aside.hidden");
+  deleteClass(sideBar, "hidden");
 }
 
 window.addEventListener("DOMContentLoaded", revealSideBar);

--- a/themes/compose/assets/js/news_display.js
+++ b/themes/compose/assets/js/news_display.js
@@ -1,39 +1,44 @@
 // JS for displaying latestNews
-$(document).ready(function() {
+function initNewsList() {
     var limitContent = 8;
     var selectorName = ".latestNews";
     var filteredNewsList = filterNewsList(selectorName, limitContent);
     var ulId = "lastestNewsList";
     displayNewsList(selectorName, filteredNewsList, ulId, function() {
-        $("#" + ulId).append('<li><a href="news">Read More</a></li>');
+        const a = createEl("a");
+        elemAttribute(a, "href", "news");
+        a.innerText = "Read More";
+        const li = createEl("li");
+        li.append(a);
+        document.querySelector(`#${ulId}`).append(li);
     });
-})
+}
 
 // Select the first n of news list
 function filterNewsList(selectorName, limitContent) {
     if (typeof limitContent !== "number" || limitContent === null)
         return;
 
-    let filteredNewsList = [];
-    $(selectorName).html(function() {
-        let li = $(this).find("li");
-        $(li).each(function(index, value){
-            if (index >= limitContent) return false;
-            filteredNewsList.push(value);
-        })
-    });
+    const li = document.querySelectorAll(`${selectorName} li`);
+    const filteredNewsList = Array.from(li).slice(0, limitContent);
 
     return filteredNewsList;
 }
 
 // Display news list
 function displayNewsList(selectorName, newsList, ulId, objCallBack) {
-    $(selectorName + " > ul").attr("id", ulId); // add id to unordered list
-    $("#" + ulId).empty(); // clear old ul
-    $.each(newsList, function(key, value) {
-        $("#" + ulId).append(value);
+    const ul = document.querySelector(`${selectorName} > ul`);
+
+    if (!ul) return;
+
+    elemAttribute(ul, "id", ulId); // add id to unordered list
+    emptyEl(ul); // clear old ul
+    newsList.forEach(function(value) {
+        ul.append(value);
     });
 
     if (typeof objCallBack !== "undefined" && objCallBack !== null)
         objCallBack();
 }
+
+initNewsList();

--- a/themes/compose/layouts/partials/scripts.html
+++ b/themes/compose/layouts/partials/scripts.html
@@ -1,5 +1,3 @@
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
-
 {{- $lunrPath := "js/lunr.js" }}
 {{- $lunr := resources.Get $lunrPath | resources.ExecuteAsTemplate $lunrPath . }}
 


### PR DESCRIPTION
Hi,

I tried to remove jQuery entirely from the codebase.  
There is a whole function that I don't think was still used. I'm talking about the one in index.js that was supposed to change the appearance of the nav bar depending on the scroll position.  
Looking for `nav_header` in the whole project didn't give me any result, so I think that function is not used anymore.

I tested the changes briefly and everything seems to work fine, but I'd appreciate if someone gave it a look since it's the first time I contribute to this project and I may have missed something.

Closes #95 