### PR TITLE
Render image only on desktop

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -31,6 +31,4 @@ title = "Taiwan Gold Card"
 
 {{< section "homePicture" >}}
 
-![Taiwan](./images/taiwan-unsplash.jpeg)
-
 {{< /section >}}

--- a/themes/compose/assets/js/index.js
+++ b/themes/compose/assets/js/index.js
@@ -397,10 +397,29 @@ function loadActions() {
   })();
 }
 
+function isMobileDevice() {
+  return (
+    typeof window.orientation !== "undefined" ||
+    navigator.userAgent.indexOf("IEMobile") !== -1
+  );
+}
+
 function revealSideBar() {
   const sideBar = document.querySelector("aside.aside.hidden");
   deleteClass(sideBar, "hidden");
 }
 
+function showHomeImage() {
+  if (!isMobileDevice()) {
+    const node = document.createElement("img");
+    node.src = "./images/taiwan-unsplash.jpeg";
+    node.alt = "Taiwan";
+    document.querySelector("section.homePicture").appendChild(node);
+  } else {
+    document.querySelector("section.homePicture").style = "display:none;";
+  }
+}
+
+window.addEventListener("DOMContentLoaded", showHomeImage);
 window.addEventListener("DOMContentLoaded", revealSideBar);
 window.addEventListener('load', loadActions());


### PR DESCRIPTION
This uses some JS code to make the home image appear only on desktop, because on mobile there's limited bandwidth so we should avoid loading such a big image on mobile. 

Other approach considered: usage of [`<picture />`](https://medium.com/@mike_masey/how-to-use-the-picture-element-to-prevent-images-loading-on-mobile-devices-1376e33b190e) element. 
* However this approach won't work because `<picture />` is generally use for rendering different sizes of images for different device size. 
* In our case, we want to completely stop rendering the home image on mobile

On desktop:

<img width="1323" alt="Screenshot 2020-09-09 at 12 41 11 AM" src="https://user-images.githubusercontent.com/977460/92504699-95490300-f235-11ea-9d73-d5f9f72c4325.png">

On mobile:
<img width="464" alt="Screenshot 2020-09-09 at 12 41 32 AM" src="https://user-images.githubusercontent.com/977460/92504723-9d08a780-f235-11ea-8ab7-ec195efff125.png">
