### PR TITLE
Fix some errors in the console

### DIFF
--- a/content/application-faq/_index.md
+++ b/content/application-faq/_index.md
@@ -22,10 +22,12 @@ If you are in Taiwan, you can head over the [National Immigration Agency](https:
  if you'd like to talk face to face to an agent. There is also [a list of helpful contact information](/application-faq/application/#who-can-i-talk-to-about-this)
 
 
-<script src="https://unpkg.com/driver.js/dist/driver.min.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/driver.js/dist/driver.min.css">
+<!--
+<script src="https://unpkg.com/driver.js@0.9.8/dist/driver.min.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/driver.js@0.9.8/dist/driver.min.css">
 
 <script>
     // const driver = new Driver();
     // driver.highlight('#docs-the-gold-card-application-faq');
 </script>
+-->

--- a/themes/compose/assets/js/index.js
+++ b/themes/compose/assets/js/index.js
@@ -410,13 +410,16 @@ function revealSideBar() {
 }
 
 function showHomeImage() {
+  const homePicture = document.querySelector("section.homePicture");
+
+  if (!homePicture) return;
   if (!isMobileDevice()) {
     const node = document.createElement("img");
-    node.src = "./images/taiwan-unsplash.jpeg";
+    node.src = "/images/taiwan-unsplash.jpeg";
     node.alt = "Taiwan";
-    document.querySelector("section.homePicture").appendChild(node);
+    homePicture.appendChild(node);
   } else {
-    document.querySelector("section.homePicture").style = "display:none;";
+    homePicture.style = "display:none;";
   }
 }
 


### PR DESCRIPTION
I noticed some errors logged in the console.

One was thrown because the `showHomeImage` function tried to `.append()` to an element that was `null`.

The other was a warning about an unexpected mime type while loading the CSS for driver.js. But I then noticed that it's not even used at the moment so I commented it out entirely to save a couple of network calls