### PR TITLE
Fix SEO stuff on home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Taiwan Gold Card"
+description = "We are a strong community of professionals with Taiwan Gold Card visa. We happily help newcomers and support each other within the Gold Card community"
 +++
 
 {{< section "newApplicant" >}}

--- a/themes/compose/assets/js/news_display.js
+++ b/themes/compose/assets/js/news_display.js
@@ -7,7 +7,7 @@ function initNewsList() {
     displayNewsList(selectorName, filteredNewsList, ulId, function() {
         const a = createEl("a");
         elemAttribute(a, "href", "news");
-        a.innerText = "Read More";
+        a.innerText = "More News »";
         const li = createEl("li");
         li.append(a);
         document.querySelector(`#${ulId}`).append(li);

--- a/themes/compose/layouts/partials/head.html
+++ b/themes/compose/layouts/partials/head.html
@@ -14,6 +14,9 @@
 
 <!-- <link rel="stylesheet" href="https://unicons.iconscout.com/release/v2.1.9/css/unicons.css"> -->
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+{{ if .Params.description }}
+<meta name="description" content="{{ .Params.description }}" />
+{{ end }}
 
 {{- partial "opengraph" . }}
 


### PR DESCRIPTION
Fix these issues for SEO on home page:

<img width="715" alt="Screenshot 2020-09-13 at 6 12 13 PM" src="https://user-images.githubusercontent.com/977460/93015513-bd958080-f5ec-11ea-923a-54273413a232.png">

Now like this:

<img width="727" alt="Screenshot 2020-09-13 at 6 11 30 PM" src="https://user-images.githubusercontent.com/977460/93015521-c8501580-f5ec-11ea-8c40-8e83f96dc670.png">

We'll probably need similar fixing on the other pages. 
