### PR TITLE
Setup proper github CI user

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           token: $${{ secrets.DEPLOY_BOT_TOKEN }}
 
-      - name: Configure CI Git User
-        run: |
-          git config --global user.name '@taiwan-bot'
-          git config --global user.email 'taiwan-bot@users.noreply.github.com'
-
       # -----
       # Install Hugo: https://github.com/peaceiris/actions-hugo
       # -----
@@ -56,7 +51,8 @@ jobs:
       # -----
       - name: Commit Files
         run: |
-          git config --local user.email "action@github.com"
+          git config --global user.name '@taiwan-bot'
+          git config --local user.email 'taiwan-bot@users.noreply.github.com'
           git config --local user.name "GitHub Action"
           CURRENTDATE=`date +"%m/%d/%Y %H:%M"`
           git add .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,11 +57,4 @@ jobs:
           CURRENTDATE=`date +"%m/%d/%Y %H:%M"`
           git add .
           git commit -am "Deploy ${CURRENTDATE} 🚀"
-
-      # -----
-      # Push changes using the action github token: https://github.com/ad-m/github-push-action
-      # -----
-      - name: Push Changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,13 @@ jobs:
       # -----
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: $${{ secrets.DEPLOY_BOT_TOKEN }}
+
+      - name: Configure CI Git User
+        run: |
+          git config --global user.name '@taiwan-bot'
+          git config --global user.email 'taiwan-bot@users.noreply.github.com'
 
       # -----
       # Install Hugo: https://github.com/peaceiris/actions-hugo
@@ -27,7 +34,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.74.3'
+          hugo-version: "0.74.3"
           extended: true
 
       # -----


### PR DESCRIPTION
Currently, branch protection is on. As a result, the default `actions-user` is not allowed to commit and push to master. 

Learn more [here](https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/35)

The remedy is to create an actual github user @taiwan-bot , with a personal access token. 