### PR TITLE
Remove type for the link:canonical tag

### DIFF
--- a/themes/compose/layouts/partials/head.html
+++ b/themes/compose/layouts/partials/head.html
@@ -5,7 +5,7 @@
 <meta name="google-site-verification" content="ssem7gWSWWGbmykaqKgVqugutzJpiZLR71gE3g4ifs0" />
 
 {{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+<link rel="{{ .Rel }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
 <link rel="apple-touch-icon" sizes="180x180" href='{{ absURL (printf "%sapple-touch-icon.png" $iconsPath) }}'>
 <link rel="icon" type="image/png" sizes="32x32" href='{{ absURL (printf "%sfavicon-32x32.png" $iconsPath) }}'>


### PR DESCRIPTION
Trying to make that [cool lightning  icon appears](https://files.slack.com/files-pri/T01AYG4DXFS-F01B7CU8MFW/image_from_ios.jpg)

Now we have 
<img width="863" alt="Screenshot 2020-09-20 at 16 50 53" src="https://user-images.githubusercontent.com/3368263/93707479-85002480-fb61-11ea-9a12-1e0c3b8ea81d.png">


I think the canonical typo  confuses the google search console : 

<img width="1544" alt="Screenshot 2020-09-20 at 16 53 05" src="https://user-images.githubusercontent.com/3368263/93707504-ca245680-fb61-11ea-877f-616f9762e7b1.png">


here the correct syntax: https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/?format=websites#amp-document-discovery


cc @matrinox 