### PR TITLE
Fix sitemap (for AMP URLs)

### DIFF
--- a/themes/compose/layouts/_default/baseof.amp.html
+++ b/themes/compose/layouts/_default/baseof.amp.html
@@ -8,8 +8,6 @@
 {{- end }}
 */}}
 
-{{ .Scratch.Set "output-format" "amp" }}
-
 <html amp lang="{{ .Site.Language.Lang }}">
 <head>
   {{- partial "head.amp" . }}

--- a/themes/compose/layouts/_default/baseof.html
+++ b/themes/compose/layouts/_default/baseof.html
@@ -8,8 +8,6 @@
 {{- end }}
 */}}
 
-{{ .Scratch.Set "output-format" "html" }}
-
 <html lang="{{ .Site.Language.Lang }}">
 <head>
   {{- partial "head" . }}

--- a/themes/compose/layouts/_default/sitemap.xml
+++ b/themes/compose/layouts/_default/sitemap.xml
@@ -1,0 +1,41 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{- $page := . }}
+  {{ range .AlternativeOutputFormats -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not $page.Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( $page.Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with $page.Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge $page.Sitemap.Priority 0.0 }}
+    <priority>{{ $page.Sitemap.Priority }}</priority>{{ end }}{{ if $page.IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink | safeURL }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink | safeURL }}"
+                />{{ end }}
+  </url>
+  {{ end -}}
+  {{ end }}
+</urlset>

--- a/themes/compose/layouts/_default/sitemap.xml
+++ b/themes/compose/layouts/_default/sitemap.xml
@@ -19,7 +19,7 @@
                 />{{ end }}
   </url>
   {{- $page := . }}
-  {{ range .AlternativeOutputFormats -}}
+  {{ with  .OutputFormats.Get "amp" -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not $page.Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( $page.Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with $page.Sitemap.ChangeFreq }}
@@ -36,6 +36,6 @@
                 href="{{ .Permalink | safeURL }}"
                 />{{ end }}
   </url>
-  {{ end -}}
+  {{- end }}
   {{ end }}
 </urlset>

--- a/themes/compose/layouts/partials/footer.html
+++ b/themes/compose/layouts/partials/footer.html
@@ -1,14 +1,7 @@
 {{ if .Site.Params.enableCopyright | default true }}
 <footer class="mt-2 pt-2 pb-2">
   <div class="wrap">
-    <p>
-    {{ if eq ($.Scratch.Get "output-format") "amp" }}
-      <a href="/amp/about">About us</a> | <a href="/amp/terms">Terms</a>
-    {{ else }}
-      <a href="/about">About us</a> | <a href="/terms">Terms</a>
-    {{ end }}
-    | Maintained by Gold Card Holders, not affiliated with any government departments, seek professional advice.
-    </p>
+    <p><a href="/about">About us</a> | <a href="/terms">Terms</a> | Maintained by Gold Card Holders, not affiliated with any government departments, seek professional advice.</p>
   </div>
 </footer>
 {{ end }}

--- a/themes/compose/layouts/partials/nav.amp.html
+++ b/themes/compose/layouts/partials/nav.amp.html
@@ -21,18 +21,14 @@
 			{{- with .Page }}
 			{{- $active = or $active ( $.IsDescendant .)  }}
 			{{- end }}
-
-      <!-- If the url does not start with the base URL, it's an external link -->
-      {{ if hasPrefix (absURL .URL) $.Site.BaseURL }}
-      {{ $refLink := ref $p (dict "path" .URL "outputFormat" "amp") }}
-      <a class="nav-link{{if $active }} active{{end}}" href="{{ $refLink }}">
-        <span{{if $active }} class="active"{{end}}>{{ .Name }}</span>
-      </a>
-			{{else}}
 			{{- $url := urls.Parse .URL }}
-      <a class="nav-link{{if $active }} active{{end}}" href="{{ $url }}">
-        <span{{if $active }} class="active"{{end}}>{{ .Name }}</span>
-      </a>
+			{{- $baseurl := $.Site.BaseURL }}
+
+			<!-- check if the link has http, if so, it's an external link -->
+			{{ if hasPrefix $url  "http" }}
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ $url }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+			{{else}}
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ $baseurl }}{{ .Permalink }}{{ else }}{{ $baseurl }}{{ .URL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
 			{{end}}
 
 		</li>


### PR DESCRIPTION
Adds all alternate output URLs (including AMP) to sitemap.

Also removes AMP links as per this comment: https://github.com/taiwangoldcard/website/issues/93#issuecomment-695806795. But this doesn't remove AMP links in the sidebar, which I think is ok since it's in the same section. But feel free to disagree, should be simple change.