### PR TITLE
Fix deploy flow to use push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,14 +5,12 @@ name: Deploy
 # -----
 
 on:
-  pull_request:
+  push:
     branches:
       - master
-    types: [closed]
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
     name: Deploy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Make it possible for the deploy bot to run even though a PR is merged from a fork.