### PR TITLE
fix More News's style on Gold Card News section

### DIFF
--- a/themes/compose/assets/js/news_display.js
+++ b/themes/compose/assets/js/news_display.js
@@ -8,6 +8,7 @@ function initNewsList() {
         const a = createEl("a");
         elemAttribute(a, "href", "news");
         a.innerText = "More News »";
+        a.setAttribute("style", "white-space: nowrap;");
         const li = createEl("li");
         li.append(a);
         document.querySelector(`#${ulId}`).append(li);


### PR DESCRIPTION
This PR will fix **More News**'s style incorrect presentation due to its word length.

 **Before**
![image](https://user-images.githubusercontent.com/9074112/95152024-b3673c00-07be-11eb-94ac-225db0b3e804.png)

**After**
![image](https://user-images.githubusercontent.com/9074112/95152041-beba6780-07be-11eb-9310-e22f5149b5c2.png)
