### PR TITLE
Hide images in AMP verisons of about & terms

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -37,7 +37,8 @@ CC-BY-SA-NC license. The license text can be found in
 {{< /column >}}
 
 {{< column >}}
-![Taiwan](/images/taiwan-unsplash.jpeg)
+{{< section "homePicture" >}}
+{{< /section >}}
 
 The following people have contributed to this site: Alvin, Antoine Scemama, Audrey Tang, Colum Brolly, Cuan-Bo Pong, Eric Khun, Geoff Lee, Ian Sinnott, Jonathan Liao, Loris Bettazza, Nuttaphat Arunoprayoch, Philip Bergvist, Rohit Dhatrak, Shawn Lim, Tom Fifield.
 

--- a/content/terms.md
+++ b/content/terms.md
@@ -31,7 +31,8 @@ The content on this website is protected by international copyright and owned by
 {{< /column >}}
 
 {{< column >}}
-![Taiwan](/images/taiwan-unsplash.jpeg)
+{{< section "homePicture" >}}
+{{< /section >}}
 
 
 {{< /column >}}

--- a/themes/compose/layouts/index.amp.html
+++ b/themes/compose/layouts/index.amp.html
@@ -1,5 +1,0 @@
-{{- define "main" }}
-<main class="home">
-  {{ .Content }}
-</main>
-{{- end }}


### PR DESCRIPTION
Fixes #163

We actually don't load the Taiwan image in mobile and since AMP is designed for mobile, I figured we'd just not load it on the about-us & terms pages as well. This should improve loading speed and thus page rankings.