### PR TITLE
Show link to latest version if on AMP

### DIFF
--- a/themes/compose/layouts/_default/baseof.amp.html
+++ b/themes/compose/layouts/_default/baseof.amp.html
@@ -22,9 +22,11 @@
   </header>
   <main class="main wrap md">
     <i>
-      You may viewing an older version of this page.
       {{ with .OutputFormats.Get "HTML" }}
-      <a href="{{ .RelPermalink }}">Click here to view the latest version</a>
+      <a href="{{ .RelPermalink }}">
+        You may viewing an older version of this page.
+        Click here to view the latest version
+      </a>
     </i>
     {{- end }}
     {{- if or (eq .Section "application-faq")  (eq .Section "goldcard-holders-faq") }}

--- a/themes/compose/layouts/_default/baseof.amp.html
+++ b/themes/compose/layouts/_default/baseof.amp.html
@@ -21,6 +21,12 @@
     {{- partial "nav.amp" . }}
   </header>
   <main class="main wrap md">
+    <i>
+      You may viewing an older version of this page.
+      {{ with .OutputFormats.Get "HTML" }}
+      <a href="{{ .RelPermalink }}">Click here to view the latest version</a>
+    </i>
+    {{- end }}
     {{- if or (eq .Section "application-faq")  (eq .Section "goldcard-holders-faq") }}
     {{- partial "document.amp" . }}
     {{- else }}

--- a/themes/compose/layouts/partials/nav.amp.html
+++ b/themes/compose/layouts/partials/nav.amp.html
@@ -1,5 +1,5 @@
 <nav class="mainNavigation">
-	<a class="mainNavigation_logoLink" href="/amp">
+	<a class="mainNavigation_logoLink" href="/">
     {{- $logos := .Site.Params.logo }}
     {{- $normalPath := absURL (printf "images/%s" $logos.lightMode) }}
     {{- $darkPath := absURL (printf "images/%s" $logos.darkMode) }}


### PR DESCRIPTION
Saw an AMP page on my phone and was reminded that Google caches AMP pages
<img width="471" alt="Screen Shot 2020-10-21 at 1 59 22 PM" src="https://user-images.githubusercontent.com/4261980/96679130-a7c26a80-13a5-11eb-880e-44ef8229f219.jpeg">

We should add a message & link to notify the user that there may be updated information. Only viewable on AMP pages of course.
<img width="471" alt="Screen Shot 2020-10-21 at 1 59 22 PM" src="https://user-images.githubusercontent.com/4261980/96679117-a2fdb680-13a5-11eb-8bf7-2c998ef720ad.png">