### PR TITLE
Add new NDC helpdesk to contact information

### DIFF
--- a/content/application-faq/_index.md
+++ b/content/application-faq/_index.md
@@ -19,7 +19,7 @@ As changes and errors may occur, please seek professional advice from the releva
 
 
 If you are in Taiwan, you can head over the [National Immigration Agency](https://www.immigration.gov.tw/5475/5478/141386/127061/127076/)
- if you'd like to talk face to face to an agent. You also try the [Gold Card Helpdesk](mailto:help@taiwangoldcard.tw) and there is also [a list of helpful contact information](/application-faq/application/#who-can-i-talk-to-about-this)
+ if you'd like to talk face to face to an agent. You can also email the [Gold Card Helpdesk](mailto:help@taiwangoldcard.tw) and there is also [a list of helpful contact information](/application-faq/application/#who-can-i-talk-to-about-this)
 
 
 <!--

--- a/content/application-faq/_index.md
+++ b/content/application-faq/_index.md
@@ -19,7 +19,7 @@ As changes and errors may occur, please seek professional advice from the releva
 
 
 If you are in Taiwan, you can head over the [National Immigration Agency](https://www.immigration.gov.tw/5475/5478/141386/127061/127076/)
- if you'd like to talk face to face to an agent. There is also [a list of helpful contact information](/application-faq/application/#who-can-i-talk-to-about-this)
+ if you'd like to talk face to face to an agent. You also try the [Gold Card Helpdesk](mailto:help@taiwangoldcard.tw) and there is also [a list of helpful contact information](/application-faq/application/#who-can-i-talk-to-about-this)
 
 
 <!--

--- a/content/application-faq/application.md
+++ b/content/application-faq/application.md
@@ -101,6 +101,7 @@ Eventually, view the preview and then hit submit!
 
 ## Who can I talk to about this?
 If you need help, the master list of contacts is [found here](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24).
+You can also try emailing the general Gold Card Helpdesk: [help@taiwangoldcard.tw](mailto:help@taiwangoldcard.tw)
 
 - If something is wrong with the online application portal, eg errors, ambiguous fields: Contact NIA, under the _Ministry of Interior for Employment Gold Card Permits for Foreign Special Professionals_ on the master list or use the number on the bottom of the application portal
 - If you don't know what documents to apply with, or which regulation to choose, contact the appropriate ministry under _Qualification of Foreign Special Professionals_ on the master list

--- a/content/application-faq/what-is-taiwan-gold-card.md
+++ b/content/application-faq/what-is-taiwan-gold-card.md
@@ -39,6 +39,7 @@ You can check [the "Fees for Employment Gold Card" section of the application po
 ## Who can I talk to about this?
 If you'd like to discuss: whether you should apply, benefits of the program, or any early questions:
 - Read the [Foreign Talent Act website](https://foreigntalentact.ndc.gov.tw/en/Default.aspx)
+- Ask [help@taiwangoldcard.tw](mailto:help@taiwangoldcard.tw), the Gold Card Helpdesk run by the National Development Council
 - Ask [Contact Taiwan](https://www.contacttaiwan.tw/main/index.aspx?lang=2#). They are a Government-funded organisation whose mission is to help you find a job. They'll direct you to the right place.
 
 Otherwise, look at the [master contact list](https://foreigntalentact.ndc.gov.tw/en/cp.aspx?n=D927ED39BDAE7478&s=DA2F7BC919B77E24) to talk about:


### PR DESCRIPTION
The NDC launched a new Gold Card Office, which has started to offer
 basic helpdesk services for new applicants or current goldcard holders
 using the temporary address help@taiwangoldcard.tw

Add this address in a few places where we mention general contact information,
 but still direct people mainly to the official contact list on the
 foreigntalentact website for now.