### PR TITLE
Add taiwan-bot chat plugin

### DIFF
--- a/themes/compose/layouts/_default/baseof.amp.html
+++ b/themes/compose/layouts/_default/baseof.amp.html
@@ -36,5 +36,6 @@
     {{- end }}
   </main>
   {{- partial "footer" . }}
+  {{- partial "chatbot" . }}
 </body>
 </html>

--- a/themes/compose/layouts/_default/baseof.html
+++ b/themes/compose/layouts/_default/baseof.html
@@ -44,28 +44,6 @@
       }
     </script>
   {{ end }}
-  <!-- Load Facebook SDK for JavaScript -->
-  <div id="fb-root"></div>
-  <script>
-    window.fbAsyncInit = function() {
-      FB.init({
-        xfbml            : true,
-        version          : 'v9.0'
-      });
-    };
-
-    (function(d, s, id) {
-    var js, fjs = d.getElementsByTagName(s)[0];
-    if (d.getElementById(id)) return;
-    js = d.createElement(s); js.id = id;
-    js.src = 'https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js';
-    fjs.parentNode.insertBefore(js, fjs);
-  }(document, 'script', 'facebook-jssdk'));</script>
-
-  <!-- Your Chat Plugin code -->
-  <div class="fb-customerchat"
-    attribution=setup_tool
-    page_id="104235498105062">
-  </div>
+  {{- partial "chatbot" . }}
 </body>
 </html>

--- a/themes/compose/layouts/_default/baseof.html
+++ b/themes/compose/layouts/_default/baseof.html
@@ -44,5 +44,28 @@
       }
     </script>
   {{ end }}
+  <!-- Load Facebook SDK for JavaScript -->
+  <div id="fb-root"></div>
+  <script>
+    window.fbAsyncInit = function() {
+      FB.init({
+        xfbml            : true,
+        version          : 'v9.0'
+      });
+    };
+
+    (function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = 'https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js';
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));</script>
+
+  <!-- Your Chat Plugin code -->
+  <div class="fb-customerchat"
+    attribution=setup_tool
+    page_id="104235498105062">
+  </div>
 </body>
 </html>

--- a/themes/compose/layouts/partials/chatbot.html
+++ b/themes/compose/layouts/partials/chatbot.html
@@ -1,0 +1,23 @@
+<!-- Load Facebook SDK for JavaScript -->
+<div id="fb-root"></div>
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      xfbml            : true,
+      version          : 'v9.0'
+    });
+  };
+
+  (function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = 'https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js';
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+
+<!-- Your Chat Plugin code -->
+<div class="fb-customerchat"
+  attribution=setup_tool
+  page_id="104235498105062">
+</div>


### PR DESCRIPTION
Fixes https://github.com/taiwangoldcard/taiwan-bot/issues/43 and https://github.com/taiwangoldcard/website/issues/167

See how this works [here](https://developers.facebook.com/docs/messenger-platform/discovery/facebook-chat-plugin/)

From [deploy preview](https://deploy-preview-176--twcms.netlify.app/):

<img width="1680" alt="Screenshot 2020-12-02 at 9 28 53 PM" src="https://user-images.githubusercontent.com/977460/100878681-77fa9c80-34e5-11eb-826f-c04eb5cd36c0.png">


This will add a chat button on the website for people to ask questions to taiwan-bot. Rides on the same infrastructure built on taiwan-bot so there will be automated answers given. 