### PR TITLE
Retire Visafinder

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 [[menu.main]]
     name = "Do I qualify?"
     weight = 1
-    url = "https://visafinder.tw/gold-card-qualification/"
+    url = "application-faq/qualifications/"
 
 [[menu.main]]
     name = "Application Process"

--- a/content/application-faq/application.md
+++ b/content/application-faq/application.md
@@ -80,7 +80,7 @@ Next, you must upload a copy of your passport's bio page. You don't need to uplo
  or any of the stamp pages - just the page that shows your profile information.
 
 Finally, based on the regulation you are applying under you will need to upload required documents.
- If you need hints on what to upload, use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/).
+ If you need hints on what to upload, use the [Gold Card Qualification Check](https://goldcard.nat.gov.tw/en/apply/step-1/).
 
 Do not stress about your application being rejected because you didn't attach enough documents.
 The authorities will ask for more documents if the ones you provided were not

--- a/content/application-faq/qualifications.md
+++ b/content/application-faq/qualifications.md
@@ -10,7 +10,7 @@ In order to qualify for an Employment Gold Card your skills must be related to o
  Science and Technology, Economics, Education, Culture and Art, Sport, Finance, Law and Architecture.
  You must select which single ministry is most relevant, and in most cases also select a specific entry in
  the list of that qualifications in that particular area for your application.
-Use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/) to find the relevant
+Use the [Gold Card Qualification Check](https://goldcard.nat.gov.tw/en/apply/step-1/) to find the relevant
  choices for you.
 
 ## Do I need to have a high salary to apply for a Gold Card?
@@ -30,7 +30,7 @@ Yes, this card is perfect for you, since it contains an open work permit that al
 
 ## Is there a "general" application category or must I select a specific industry? 
 There is no "general" application category. You must select a single ministry to assess your skills.
-Use the [Gold Card Qualification Check](https://visafinder.tw/gold-card-qualification/) to find suggestions.
+Use the [Gold Card Qualification Check](https://goldcard.nat.gov.tw/en/apply/step-1/) to find suggestions.
 
 ## Does my professional services/sole proprietor/dividend income count towards the salary requirement for Gold Card application?
 Generally not, but it depends. The document requirements to prove an Article 1 ("salary")


### PR DESCRIPTION
visafinder.tw has long hosted the gold card quick qualification
check. It has worked well, but always looked terrible, and the
server its on sometimes goes down for long periods.

Now the official folks have adopted the idea, and it's hosted on
a site with a very high uptime, and dedicated resources to keep
it up to date. Therefore, I think it's time to retire visafinder.

This patch changes the links from visafinder to
https://goldcard.nat.gov.tw/en/apply/step-1/

and updates the "Do I Qualify" link to point to our own qualification
section instead of the external site.

fixes #188