### PR TITLE
Update health-insurance.md

### DIFF
--- a/content/goldcard-holders-faq/health-insurance.md
+++ b/content/goldcard-holders-faq/health-insurance.md
@@ -93,4 +93,4 @@ Notes:
 * Some types of income attract a higher rate (e.g. bonuses and investment income). 
 * There are income tax deductions available for NHI premium payments.
 
-To calculate your exact NHI premium, refer to the official information (and description of the many 'special' cases) which can be found on [the NHI website](https://www.nhi.gov.tw/english/Content_List.aspx?n=B9C9C690524F2543&topn=46FA76EB55BC2CB8).
+To calculate your exact NHI premium, refer to the official information (and description of the many 'special' cases) which can be found on [the NHI website](https://eng.nhi.gov.tw/en/sitemap-2.html).


### PR DESCRIPTION
The original link  to the NHI page about calculating premiums for 'special' cases is broken and returns an error page. I'm not sure where the original link was supposed to point, so as a temporary fix I changed the link to the English language version of the NHI site map.

![image](https://github.com/taiwangoldcard/website/assets/73149125/bda53cdc-5455-48fd-a5dd-1451999179b7)
