### PR TITLE
Add links to monthly events

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,10 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     name = "Community"
     weight = 4
     url = "community"
+[[menu.main]]
+    name = "Events"
+    weight = 5
+    url = "https://lu.ma/calendar/cal-YD66Z9Ov9mm8M2z"
 
 
 [markup]

--- a/content/_index.md
+++ b/content/_index.md
@@ -23,7 +23,8 @@ description = "We are a strong community of professionals with Taiwan Gold Card 
 * Access to our chat group where we help each other
 * Jobs opportunities that require our expertise
 * Visibility if you are looking for new opportunities
-* Receive a regular newsletter with the latest Gold Card News
+* Monthly organized events by the community
+
 
 {{< button "https://join.taiwangoldcard.com" "Join the Gold Card Community" >}}
 {{< button "goldcard-holders-faq/" "Resources for Gold Card holders" >}}

--- a/content/community.md
+++ b/content/community.md
@@ -2,7 +2,7 @@
 title: "Taiwan Gold Card Community"
 ---
 
-> #### We are a community of Gold Card Holders supporting each other. We meet regularly through monthly events. If you have the Employment Gold Card and want to be part to the community, feel free to fill the [Form](https://join.taiwangoldcard.com). If you want to contribute your profile here, please use the [Form](https://docs.google.com/forms/d/e/1FAIpQLSdvAaNx-R5Np1iDK2_Iz5Kg1eASOUgK-jENuWIR6S855LeDwg/viewform).
+> #### We are a community of Gold Card Holders supporting each other. We meet regularly through [monthly events](https://lu.ma/calendar/cal-YD66Z9Ov9mm8M2z). If you have the Employment Gold Card and want to be part to the community, feel free to fill the [Form](https://join.taiwangoldcard.com). If you want to contribute your profile here, please use the [Form](https://docs.google.com/forms/d/e/1FAIpQLSdvAaNx-R5Np1iDK2_Iz5Kg1eASOUgK-jENuWIR6S855LeDwg/viewform).
 
 {{< block "grid-2" >}}
 


### PR DESCRIPTION
Add a link to this calendar: https://lu.ma/calendar/cal-YD66Z9Ov9mm8M2z

Was discussing about this with Paul and Colum. This worked well back in 2020. Could be a good way to connect every fields with a low pressure environment. No organization/meeting needed. We just stick to  every 2nd Thursday of the month. 
